### PR TITLE
Scraper uses python3 features, so call that explicitly

### DIFF
--- a/Counties/Florida/Bay County/README.md
+++ b/Counties/Florida/Bay County/README.md
@@ -25,7 +25,7 @@ Bay County uses a Benchmark portal by Pioneer Technology .
 
 8. Verify tesseract is installed in PATH by opening cmd and entering `tesseract`.
 
-9. `python Scraper.py [args]` (See below for args) 
+9. `python3 Scraper.py [args]` (See below for args) 
 
 ## Args
 


### PR DESCRIPTION
Docs didn't work for me, as `python` is the python2 binary and not python3 in Debian 10 (I don't know of OSes where python is python3, but it would make sense for them to exist).