### PR TITLE
rm getopts from reqs; it's in the standard library

### DIFF
--- a/Counties/Florida/Bay County/Scraper/requirements.txt
+++ b/Counties/Florida/Bay County/Scraper/requirements.txt
@@ -1,5 +1,4 @@
 selenium
-getopt
 opencv-python
 pytesseract
 pytest


### PR DESCRIPTION
This was blocking requirements installation. It's not in Pip, it seems, as it's part of the standard library. 