### PR TITLE
Add the PDAP Product Subteams doc.

### DIFF
--- a/Organization/PDAP_Product_Subteams.md
+++ b/Organization/PDAP_Product_Subteams.md
@@ -1,0 +1,24 @@
+# PDAP Product Sub-teams
+
+The Product Team will consist of three sub-teams that will work closely
+together for a streamlined process of information flow; and will also be in
+frequent contact with the Oversight Team to ensure legal compliance and best
+practices.
+
+## Collection Team - Data Engineers
+
+The Collection Team is responsible for defining data architecture and scope, as
+well as creating and maintaining codebases pertinent to the retrieval of public
+records.
+
+## Infrastructure Team - DevOps Engineers
+
+The Infrastructure Team is responsible for creating, maintaining, and checking
+the health and security of digital infrastructure. This includes all aspects of
+deployment.
+
+## Distribution Team - Back-end Engineers
+
+The Distribution Team is responsible for creating and maintaining codebases
+responsible for distribution of data, as well as integrations with third party
+workflows.


### PR DESCRIPTION
While we're here, make a directory called Organization, since I imagine
we'll be seeing similar docts to this in the future.