### PR TITLE
Better attachment downloading. Handle timeout/retries better. Various fixes.

### DIFF
--- a/Counties/Florida/Bay County/README.md
+++ b/Counties/Florida/Bay County/README.md
@@ -31,7 +31,7 @@ Bay County uses a Benchmark portal by Pioneer Technology .
 
 |Short|Long|Default Value|Description|
 |---|---|---|---|
-|`-p`|`--portal-home`|[Portal link](https://court.baycoclerk.com/BenchmarkWeb2/Home.aspx/Search)|Set homepage for county portal.|
+|`-p`|`--portal-base`|https://court.baycoclerk.com/BenchmarkWeb2/|Base URL for the Benchmark-based portal|
 |`-s`|`--state`|FL|Postal code for state being scraped.
 |`-c`|`--county`|Bay|County being scraped.
 |`-y`|`--start-year`|2000|Earliest year to scrape as 4-digit year.|
@@ -40,7 +40,7 @@ Bay County uses a Benchmark portal by Pioneer Technology .
 |`-p`|`--collect-pii`|N/A (Off by default)|Collect Personally Identifiable Information (PII).|
 |`-c`|`--connect-thresh`|10|How many times to attempt to connect to a page before failing.
 |`-o`|`--output`|bay-county-scraped|Output CSV name. The .csv file extension is not required.
-|`-a`|`--save-attachments`|N/A (Off by default)|Save attached documents (eg: police citation scans) to 'attachments' folder. Disabled by default as these attachments contain embedded PII. 
+|`-a`|`--save-attachments`|none|Save case docket attached documents. Disabled by default as these documents contain embedded PII. Valid values: `none` / `filing` / `all`. The `filing` option saves only attachments related to the case or citation filing.
 |`-u`|`--solve-captchas`|N/A (Off by default)|Automatically solve captchas used on the portal.
 |`-v`|`--verbose`|N/A (Off by default)|Run in Verbose mode with lots of printing
 

--- a/Counties/Florida/Bay County/Scraper/requirements.txt
+++ b/Counties/Florida/Bay County/Scraper/requirements.txt
@@ -3,3 +3,5 @@ opencv-python
 pytesseract
 pytest
 pathvalidate
+requests
+requests-toolbelt

--- a/Counties/Florida/Bay County/Scraper/tests/test_ScraperUtils.py
+++ b/Counties/Florida/Bay County/Scraper/tests/test_ScraperUtils.py
@@ -70,6 +70,18 @@ class TestScraperUtils:
         filename_invalid_chars = 't<>:e"/s\\t|?n*ame'
         assert ScraperUtils.parse_out_path('', filename_invalid_chars, 'pdf') == os.path.join('', 'testname.pdf')
 
+    def test_parse_out_path_valid(self):
+        # Function should not affect valid length filenames and paths.
+        normal_filename = 'document'
+        parsedPath = ScraperUtils.parse_out_path('C:\\Example\Path', normal_filename, 'pdf')
+        assert parsedPath == os.path.join('C:\\Example\Path', '{}.{}'.format(normal_filename, 'pdf'))
+
+    def test_parse_out_path_filename_extension_shortening(self):
+        # 252 characters long, but with the .pdf extension it becomes 256 characters long - one too many.
+        filename = '012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901'
+        parsed_filename = ScraperUtils.parse_out_path('', filename, 'pdf')
+        assert parsed_filename == '{}.{}'.format(filename[:-1], 'pdf')
+
     def test_parse_out_path_shortening(self):
         # 260 characters long before the extension. This is an invalid filename in Windows.
         filename_too_long = '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789'


### PR DESCRIPTION
This is the same PR as in #66 which was not properly merged due to the repo being rebased to remove some PII.

* Solves significant issues with the original attachment downloading technique

The old technique used the browser to download the attachments by clicking on the links. The problem with this is it did not allow for them to be given a custom name. The script would watch the download folder and look for new files, then rename them with the desired name. The problem was that in some circumstances files might not be renamed. Sometimes 0-byte files were saved because of a race condition between Firefox's file writer and the rename script.

This new technique copies the GET and POST requests made by the website using the requests library. This involved cloning the user agent, headers, and cookies to preserve the session from Selenium, as access is tied to the browser session. This took some time, but is a much better implementation.

* Allows configuration of which attachments to download. `none`/`filing`/`all`. This is because most attachments are not necessary except the case/citation filings, which contain some required fields.

* Handles timeout errors/retries better

* Addresses an exception thrown when the portal displays the PLAINTIFF/DEFENDANT table in reversed order in rare cases.

* Fixes the use of short args

* Better parses the output filename
